### PR TITLE
Fix cross-platform release blockers for Preview 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sync-show",
-  "version": "1.4.0-preview.17",
+  "version": "1.4.0-preview.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sync-show",
-      "version": "1.4.0-preview.17",
+      "version": "1.4.0-preview.18",
       "license": "MIT",
       "dependencies": {
         "jszip": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sync-show",
-  "version": "1.4.0-preview.17",
+  "version": "1.4.0-preview.18",
   "description": "Synchronized configurable presentation outputs for church services",
   "main": "main.js",
   "scripts": {

--- a/src/services/project/NativeSlideRenderer.js
+++ b/src/services/project/NativeSlideRenderer.js
@@ -293,6 +293,16 @@ function focalGravity(focalPoint = { x: 0.5, y: 0.5 }) {
   return `${vertical}${horizontal}` || 'centre';
 }
 
+function alignedLayerLeft(canvasWidth, layerWidth, regionWidth, alignment) {
+  const boundedRegionWidth = Math.min(canvasWidth, Math.max(0, Math.round(regionWidth)));
+  const regionLeft = Math.round((canvasWidth - boundedRegionWidth) / 2);
+  if (alignment === 'left') return regionLeft;
+  if (alignment === 'right') {
+    return Math.max(regionLeft, regionLeft + boundedRegionWidth - layerWidth);
+  }
+  return Math.round((canvasWidth - layerWidth) / 2);
+}
+
 class NativeSlideRenderer {
   constructor(options = {}) {
     this.width = Number.isSafeInteger(options.width) ? options.width : 1920;
@@ -403,16 +413,22 @@ class NativeSlideRenderer {
     const preset = resolveNativeTextPreset(presetId).render;
     const composites = [];
     const hasTitle = Boolean(String(title || '').trim()) && preset.showTitle;
+    const resolutionScale = Math.min(1, this.width / 1920, this.height / 1080);
     let titleBottom = 0;
     if (hasTitle) {
+      const titleWidth = this.width * 0.82;
+      const titleAlign = preset.titleAlign || 'center';
       const titleLayer = await this._textLayer(title, {
-        width: this.width * 0.82,
+        width: titleWidth,
         maxHeight: this.height * 0.16,
         fontSize: preset.titleSize,
-        minimumFontSize: preset.titleMinimumSize,
+        minimumFontSize: Math.max(
+          14,
+          Math.round(preset.titleMinimumSize * resolutionScale)
+        ),
         foreground: preset.titleForeground || '#93b4ff',
         weight: preset.titleWeight || '650',
-        align: preset.titleAlign || 'center'
+        align: titleAlign
       });
       if (titleLayer) {
         const titleTop = preset.titleTopPercent === undefined
@@ -420,7 +436,12 @@ class NativeSlideRenderer {
           : Math.round(this.height * preset.titleTopPercent / 100);
         composites.push({
           input: titleLayer.data,
-          left: Math.round((this.width - titleLayer.info.width) / 2),
+          left: alignedLayerLeft(
+            this.width,
+            titleLayer.info.width,
+            titleWidth,
+            titleAlign
+          ),
           top: titleTop
         });
         titleBottom = titleTop + titleLayer.info.height;
@@ -440,14 +461,19 @@ class NativeSlideRenderer {
           Math.max(50, this.height - availableTop - Math.round(this.height * 0.06))
         )
       : Math.min(preset.bodyHeight, this.height * (hasTitle ? 0.66 : 0.78));
+    const bodyWidth = this.width * (preset.bodyWidthPercent || 82) / 100;
+    const bodyAlign = preset.bodyAlign || 'center';
     const bodyLayer = await this._textLayer(body || title, {
-      width: this.width * (preset.bodyWidthPercent || 82) / 100,
+      width: bodyWidth,
       maxHeight: bodyMaximumHeight,
       fontSize: preset.bodySize,
-      minimumFontSize: preset.bodyMinimumSize,
+      minimumFontSize: Math.max(
+        14,
+        Math.round(preset.bodyMinimumSize * resolutionScale)
+      ),
       foreground: preset.bodyForeground || '#f8fafc',
       weight: preset.bodyWeight,
-      align: preset.bodyAlign || 'center',
+      align: bodyAlign,
       lineSpacingPercent: preset.lineSpacingPercent,
       paragraphGap: preset.paragraphGap,
       // Imported blocks carry source-authoritative spans. When any are
@@ -462,7 +488,12 @@ class NativeSlideRenderer {
     if (bodyLayer) {
       composites.push({
         input: bodyLayer.data,
-        left: Math.round((this.width - bodyLayer.info.width) / 2),
+        left: alignedLayerLeft(
+          this.width,
+          bodyLayer.info.width,
+          bodyWidth,
+          bodyAlign
+        ),
         top: preset.bodyPosition === 'top'
           ? availableTop
           : availableTop + Math.max(0, Math.round((oldAvailableHeight - bodyLayer.info.height) / 2))

--- a/src/services/project/ShowPackagePublisher.js
+++ b/src/services/project/ShowPackagePublisher.js
@@ -93,7 +93,11 @@ function requireRoleId(value, field) {
 }
 
 async function syncRegularFile(filePath) {
-  const handle = await fs.open(filePath, 'r');
+  // Windows requires a writable handle for FlushFileBuffers, which is what
+  // FileHandle.sync() uses. These thumbnail files were just created by the
+  // publisher, so opening them read/write keeps the durability guarantee
+  // without turning a supported Windows publish into EPERM.
+  const handle = await fs.open(filePath, 'r+');
   try {
     await handle.sync();
   } finally {

--- a/test/google-drive-build-config.test.js
+++ b/test/google-drive-build-config.test.js
@@ -227,10 +227,10 @@ test('packaged app verification rejects a mismatched client secret without echoi
 });
 
 test('release workflow scopes secrets to injection and always removes generated config', async () => {
-  const workflow = await fs.readFile(
+  const workflow = (await fs.readFile(
     path.resolve(__dirname, '../.github/workflows/build.yml'),
     'utf8'
-  );
+  )).replace(/\r\n/g, '\n');
   const clientIdBindings = workflow.match(
     /SYNCSHOW_GOOGLE_CLIENT_ID:\s*\$\{\{\s*secrets\.SYNCSHOW_GOOGLE_CLIENT_ID\s*\}\}/g
   ) || [];

--- a/test/july19-native-service-rebuild.test.js
+++ b/test/july19-native-service-rebuild.test.js
@@ -65,11 +65,11 @@ test('July 19 rebuild arguments keep every local input and output explicit', () 
     '--report', '/tmp/report.json'
   ]);
   assert.deepEqual(parsed, {
-    templatePath: '/tmp/template.syncshow-service',
-    catalogPath: '/tmp/catalog.syncshow-service',
-    workRoot: '/tmp/work',
-    outputPath: '/tmp/output.syncshow-service',
-    reportPath: '/tmp/report.json'
+    templatePath: path.resolve('/tmp/template.syncshow-service'),
+    catalogPath: path.resolve('/tmp/catalog.syncshow-service'),
+    workRoot: path.resolve('/tmp/work'),
+    outputPath: path.resolve('/tmp/output.syncshow-service'),
+    reportPath: path.resolve('/tmp/report.json')
   });
 });
 

--- a/test/renderer-contract.test.js
+++ b/test/renderer-contract.test.js
@@ -6,17 +6,18 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const rendererDirectory = path.join(__dirname, '..', 'src', 'renderer');
-const html = fs.readFileSync(path.join(rendererDirectory, 'index.html'), 'utf8');
-const appSource = fs.readFileSync(path.join(rendererDirectory, 'app.js'), 'utf8');
-const prepareSource = fs.readFileSync(path.join(rendererDirectory, 'prepare-controller.js'), 'utf8');
-const mainSource = fs.readFileSync(path.join(__dirname, '..', 'main.js'), 'utf8');
-const preloadSource = fs.readFileSync(path.join(__dirname, '..', 'preload.js'), 'utf8');
-const displayHtml = fs.readFileSync(path.join(rendererDirectory, 'display.html'), 'utf8');
-const displaySource = fs.readFileSync(path.join(rendererDirectory, 'display.js'), 'utf8');
-const nativeCueSource = fs.readFileSync(path.join(rendererDirectory, 'native-cue-renderer.js'), 'utf8');
-const singerHtml = fs.readFileSync(path.join(rendererDirectory, 'singer.html'), 'utf8');
-const singerSource = fs.readFileSync(path.join(rendererDirectory, 'singer.js'), 'utf8');
-const bibleOverlaySource = fs.readFileSync(path.join(rendererDirectory, 'bible-overlay.js'), 'utf8');
+const readSource = filePath => fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+const html = readSource(path.join(rendererDirectory, 'index.html'));
+const appSource = readSource(path.join(rendererDirectory, 'app.js'));
+const prepareSource = readSource(path.join(rendererDirectory, 'prepare-controller.js'));
+const mainSource = readSource(path.join(__dirname, '..', 'main.js'));
+const preloadSource = readSource(path.join(__dirname, '..', 'preload.js'));
+const displayHtml = readSource(path.join(rendererDirectory, 'display.html'));
+const displaySource = readSource(path.join(rendererDirectory, 'display.js'));
+const nativeCueSource = readSource(path.join(rendererDirectory, 'native-cue-renderer.js'));
+const singerHtml = readSource(path.join(rendererDirectory, 'singer.html'));
+const singerSource = readSource(path.join(rendererDirectory, 'singer.js'));
+const bibleOverlaySource = readSource(path.join(rendererDirectory, 'bible-overlay.js'));
 
 function matches(source, expression) {
   return [...source.matchAll(expression)].map(match => match[1]);


### PR DESCRIPTION
## Summary

This is the narrow portability follow-up required to produce today's cross-platform SyncShow release.

- opens generated thumbnail files read/write before `fsync`, which Windows requires
- positions left/right-aligned native text against its configured region instead of a platform-dependent trimmed bitmap
- allows safe minimum-font scaling on low-resolution render targets
- normalizes CRLF-sensitive source/workflow contract tests
- makes the July 19 developer-path assertion platform-native
- advances the prerelease to `1.4.0-preview.18`

## Validation

- 81 JavaScript files passed syntax checks
- 520/520 non-loopback tests passed
- 51/51 focused publisher, renderer, Drive, rebuild, and end-to-end tests passed
- all seven published blobs exactly match the locally tested files

The three omitted local tests require binding a loopback Remote-Control port, which this sandbox denies with `listen EPERM`; GitHub CI runs them on normal hosts.